### PR TITLE
Add fields in offensesummary query

### DIFF
--- a/fn_qradar_enhanced_data/fn_qradar_enhanced_data/util/qradar_graphql_queries.py
+++ b/fn_qradar_enhanced_data/fn_qradar_enhanced_data/util/qradar_graphql_queries.py
@@ -30,6 +30,14 @@ GRAPHQL_OFFENSEQUERY = '''query offenseQuery($id: ID!) {
                                 eventCount
                                 flowCount
                                 __typename
+                                status
+                                domain {
+                                    id
+                                    name
+                                    __typename
+                                }
+                                startTime
+                                lastUpdatedTime
                             }
                         }
                        '''


### PR DESCRIPTION
## Description
Add usefull fields in offensesummary query to populate result and therefore be able to run logic on those result fields : status, domain, startTime and lastUpdatedTime

## Motivation and Context
I would like to have those fields to run playbooks that check the offense status and domain before doing other checks.
Getting offense status from Qradar is usefull in case sync between QRadar and SOAR is down for some times. Status is never updated for old offense then. Returning those fields allows to create a playbook that would, for example, resync status for offense comparing status in QRadar and Resilient to ensure consistancy.
StartTime and LastUpdatedTime will be usefull for futur playbook I plan to create.

## How Has This Been Tested?
Query tested on : https://qradar_instance/console/graphql

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: IMSdevsecu <88375366+IMSdevsecu@users.noreply.github.com>
